### PR TITLE
use std atomics

### DIFF
--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -269,7 +269,7 @@ impl Value {
         if floor == ceil {
             self.u64.add(floor);
         } else {
-            self.f64.update(|v| v + count);
+            self.f64.add(count);
         }
     }
 

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -68,7 +68,7 @@ impl Gauge {
     /// Adds `count` to this gauge.
     #[inline]
     pub fn add(&self, count: f64) {
-        self.0.value.update(|v| v + count);
+        self.0.value.add(count);
     }
 
     /// Decrements this gauge.

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -88,7 +88,7 @@ impl Histogram {
             .binary_search_by(|b| b.upper_bound().partial_cmp(&value).expect("Never fails"))
             .unwrap_or_else(|i| i);
         self.0.buckets.get(i).map(|b| b.increment());
-        self.0.sum.update(|v| v + value);
+        self.0.sum.add(value);
     }
 
     /// Measures the exeuction time of `f` and observes its duration in seconds.

--- a/src/metrics/summary.rs
+++ b/src/metrics/summary.rs
@@ -103,7 +103,7 @@ impl Summary {
             samples.push_back((now, value));
         });
         self.0.count.inc();
-        self.0.sum.update(|v| v + value);
+        self.0.sum.add(value);
     }
 
     /// Measures the exeuction time of `f` and observes its duration in seconds.


### PR DESCRIPTION
- requires rustc >= 1.34
- get rid of unsafe f64 -> u64 conversions
- even 32-bit archs usually support 64-bit atomics - let stdlib worry about it
- `Relaxed` is good enough: we don't synchronize access to other data using the counters, so no ordering with other instructions is necessary.