### PR TITLE
timestamp_mut() doesn't need mutable reference

### DIFF
--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -62,7 +62,7 @@ impl Counter {
     }
 
     /// Returns the mutable timestamp of this counter.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -49,7 +49,7 @@ impl Gauge {
     }
 
     /// Returns the mutable timestamp of this gauge.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -53,7 +53,7 @@ impl Histogram {
     }
 
     /// Returns the mutable timestamp of this histogram.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/summary.rs
+++ b/src/metrics/summary.rs
@@ -55,7 +55,7 @@ impl Summary {
     }
 
     /// Returns the mutable timestamp of this summary.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 


### PR DESCRIPTION
This removes the need to call clone() before timestamp_mut().