### PR TITLE
Allow setting multiple buckets at once

### DIFF
--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -269,7 +269,7 @@ impl Value {
         if floor == ceil {
             self.u64.add(floor);
         } else {
-            self.f64.update(|v| v + count);
+            self.f64.add(count);
         }
     }
 

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -62,7 +62,7 @@ impl Counter {
     }
 
     /// Returns the mutable timestamp of this counter.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -68,7 +68,7 @@ impl Gauge {
     /// Adds `count` to this gauge.
     #[inline]
     pub fn add(&self, count: f64) {
-        self.0.value.update(|v| v + count);
+        self.0.value.add(count);
     }
 
     /// Decrements this gauge.

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -49,7 +49,7 @@ impl Gauge {
     }
 
     /// Returns the mutable timestamp of this gauge.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -53,7 +53,7 @@ impl Histogram {
     }
 
     /// Returns the mutable timestamp of this histogram.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -88,7 +88,7 @@ impl Histogram {
             .binary_search_by(|b| b.upper_bound().partial_cmp(&value).expect("Never fails"))
             .unwrap_or_else(|i| i);
         self.0.buckets.get(i).map(|b| b.increment());
-        self.0.sum.update(|v| v + value);
+        self.0.sum.add(value);
     }
 
     /// Measures the exeuction time of `f` and observes its duration in seconds.

--- a/src/metrics/summary.rs
+++ b/src/metrics/summary.rs
@@ -103,7 +103,7 @@ impl Summary {
             samples.push_back((now, value));
         });
         self.0.count.inc();
-        self.0.sum.update(|v| v + value);
+        self.0.sum.add(value);
     }
 
     /// Measures the exeuction time of `f` and observes its duration in seconds.

--- a/src/metrics/summary.rs
+++ b/src/metrics/summary.rs
@@ -55,7 +55,7 @@ impl Summary {
     }
 
     /// Returns the mutable timestamp of this summary.
-    pub fn timestamp_mut(&mut self) -> TimestampMut {
+    pub fn timestamp_mut(&self) -> TimestampMut {
         TimestampMut::new(&self.0.timestamp)
     }
 


### PR DESCRIPTION
## Purpose

Allow setting multiple buckets at once. We can avoid manual iteration like `buckets.into_iter().for_each(|n| builder.bucket(n));` by this feature.